### PR TITLE
Cleaned up README.md: Changed setup, added License & Contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Scrybe
-Scrybe is a simple terminal application for taking notes, using your favourite terminal editor, and storing them in an sqlite database. Notes consist of a title, a body and a set of comma separated tags that can be used to sort them however you like. Scrybe includes a search function at the minute, and a filtering function to allow you to view all the notes of a certain tag will be added when I get around to it. Don't like something, or want something? Add an issue, submit a pull request or fork the repo :). There is a todo file, but I won't promise to keep it exceptionally up to date.
+Scrybe is a simple terminal application for taking notes, using your favourite terminal editor, and storing them in an sqlite database. Notes consist of a title, a body and a set of comma separated tags that can be used to sort them however you like. Scrybe includes a search function at the minute, and a filtering function to allow you to view all the notes of a certain tag will be added when I get around to it.
+
+### Contribution
+
+Don't like something, or want something? Add an issue, submit a pull request or fork the repo :). There is a todo file, but I won't promise to keep it exceptionally up to date.
 
 ## Setup:
 
-* Clone the repo:
-`git clone https://github.com/oliverb123/scrybe scrybe/`
+```bash
+git clone https://github.com/oliverb123/scrybe scrybe/
+# Clone the repository
+cd scrybe/
+# Change directory into scrybe/
+python setup.py
+# Run the setup python script
+```
+After that, you have to chose your preferred editor,
+`vim, emacs, or nano?: vim`
 
-* Change directory in to ./scrybe:
-`cd scrybe`
-
-* Run setup.py:
-`python setup.py`
-
-* Choose the best editor:
-`Vim, emacs or nano?: Vim`
-
-That's it. `scrybe` is now an alias in your .bashrc, and you're good to go
+That's it, `scrybe` will now be an alias in your .bashrc, or the current shell you are using.
+Now you're off to the races!  
 
 ## Usage
 
@@ -83,4 +87,8 @@ tags, createTime and whether or not it's archived)
 
 * q/Q : close scrybe
 
-### Enjoy!!
+# License
+
+Scrybe is licensed under the MIT license. See the LICENSE file for more information.
+
+# Enjoy!!


### PR DESCRIPTION
I cleaned up the README a bit. 
I made the setup section a giant block with comments, so that if a person wanted to install via copy and paste, they can.
I also added a section for Licence, with just says that the program is under the MIT license.
Contribution just takes what the developer has said in the introduction, but specific under a Contribution section. 